### PR TITLE
Fix home directories with spaces in the path

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,23 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Shellcheck
+
+# Controls when the action will run. 
+on:
+  push:
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck 
+      - name: shellcheck install.sh
+        run: shellcheck install.sh

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 set -e
 
 echo "Starting clerkie-cli install"
@@ -8,22 +9,22 @@ python3 -m pip install rich
 echo "Done pip installs"
 
 main() {
-    CLERKIE_DIR=$HOME/.clerkie-cli
-    START=$PWD
-    mkdir -p $CLERKIE_DIR
-    cd $CLERKIE_DIR
+    CLERKIE_DIR="$HOME/.clerkie-cli"
+    START="$PWD"
+    mkdir -p "$CLERKIE_DIR"
+    cd "$CLERKIE_DIR"
 
     RELEASE_URL="https://github.com/ishaan-jaff/clerkie-cli/archive/refs/tags/v0.0.2-beta.zip"
     echo "$RELEASE_URL"
 
     echo "downloading latest release in $CLERKIE_DIR"
-    ensure curl -L "$RELEASE_URL" -o $CLERKIE_DIR/release.zip
-    chmod +x $CLERKIE_DIR/release.zip
-    unzip -q -o $CLERKIE_DIR/release.zip
-    rm $CLERKIE_DIR/release.zip
+    ensure curl -L "$RELEASE_URL" -o "$CLERKIE_DIR/release.zip"
+    chmod +x "$CLERKIE_DIR/release.zip"
+    unzip -q -o "$CLERKIE_DIR/release.zip"
+    rm "$CLERKIE_DIR/release.zip"
     echo "installed clerkie and unzipped"
 
-    FOLDER_NAME=$(ls -d */ | head -n 1)
+    FOLDER_NAME=$(find . -maxdepth 1 -type d -not -path . | head -n 1)
     if [ -d "$FOLDER_NAME" ]; then
       echo "renaming $FOLDER_NAME"
       mv "$FOLDER_NAME" "clerkie-src"
@@ -31,11 +32,13 @@ main() {
       echo "Error: No folder found in the current working directory."
     fi
 
-    echo "# clerkie-cli configs" >>$HOME/.zshrc
-    echo "export CLERKIE_SRC=$CLERKIE_DIR/clerkie-src" >>$HOME/.zshrc
-    echo '[[ -f "$HOME/.clerkie-cli/clerkie-src/setup.sh" ]] && builtin source "$HOME/.clerkie-cli/clerkie-src/setup.sh"' >>$HOME/.zshrc
+    { echo "# clerkie-cli configs";
+      echo "export CLERKIE_SRC=\"$CLERKIE_DIR/clerkie-src\"";
+      echo "[[ -f \"\$HOME/.clerkie-cli/clerkie-src/setup.sh\" ]] && builtin source \"\$HOME/.clerkie-cli/clerkie-src/setup.sh\"" 
+    } >>"$HOME/.zshrc"
+
     echo "Clerkie Installed. Open a new Terminal Window to start using"
-    cd $START
+    cd "$START"
 }
 
 ensure() {

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,8 @@
-LOG_FILE=$CLERKIE_SRC/c.log
-SCRIPT_PATH=$CLERKIE_SRC/call_clerkie.py
+LOG_FILE="$CLERKIE_SRC/c.log"
+SCRIPT_PATH="$CLERKIE_SRC/call_clerkie.py"
 
 setup_capture_hook() {
-    exec 2> >(tee $LOG_FILE)
+    exec 2> >(tee "$LOG_FILE")
     echo "Clerkie Activated."
 }
 


### PR DESCRIPTION
When the home directory path has a space in the path we get an error like this:

```bash
https://github.com/ishaan-jaff/clerkie-cli/archive/refs/tags/v0.0.2-beta.zip
main: line 14: cd: too many arguments
downloading latest release in /home/nicolas/foo bar//.clerkie-cli
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to open the file /home/nicolas/foo: Is a directory
100   512    0   512    0     0    578      0 --:--:-- --:--:-- --:--:--  2081
curl: (23) Failure writing output to destination
curl: (6) Could not resolve host: bar
main: line 42: err: command not found
chmod: cannot access 'bar//.clerkie-cli/release.zip': No such file or directory
unzip:  cannot find or open /home/nicolas/foo, /home/nicolas/foo.zip or /home/nicolas/foo.ZIP.
rm: cannot remove '/home/nicolas/foo': Is a directory
rm: cannot remove 'bar//.clerkie-cli/release.zip': No such file or directory
installed clerkie and unzipped
renaming bar/
Clerkie Installed. Open a new Terminal Window to start using
```

This PR fixes this error by properly quoting all variables. I also fix other shellcheck linting issues and add a GitHub action to automatically check the install script for linting issues.